### PR TITLE
lowercase only Request keys

### DIFF
--- a/titiler/application/titiler/application/main.py
+++ b/titiler/application/titiler/application/main.py
@@ -9,7 +9,7 @@ from titiler.application.middleware import (
     CacheControlMiddleware,
     LoggerMiddleware,
     TotalTimeMiddleware,
-    CaseInsensitiveMiddleware
+    LowerCaseQueryStringMiddleware
 )
 from titiler.application.routers import cog, mosaic, stac, tms
 from titiler.application.settings import ApiSettings
@@ -68,12 +68,12 @@ app.add_middleware(
     exclude_path={r"/healthz"},
 )
 
-app.add_middleware(CaseInsensitiveMiddleware)
-
 if api_settings.debug:
     app.add_middleware(LoggerMiddleware, headers=True, querystrings=True)
     app.add_middleware(TotalTimeMiddleware)
 
+if api_settings.lower_case_query_parameters:
+    app.add_middleware(LowerCaseQueryStringMiddleware)
 
 @app.get("/healthz", description="Health Check", tags=["Health Check"])
 def ping():

--- a/titiler/application/titiler/application/middleware.py
+++ b/titiler/application/titiler/application/middleware.py
@@ -100,13 +100,11 @@ class LowerCaseQueryStringMiddleware(BaseHTTPMiddleware):
 
         query_string = ""
         for k in request.query_params:
-            query_string += k.lower() + '=' + request.query_params[k]
+            query_string += k.lower() + '=' + request.query_params[k] + "&"
+
+        query_string = query_string[:-1]
         request.scope["query_string"] = query_string.encode(self.DECODE_FORMAT)
 
-        print(request.scope["query_string"])
-
-        #raw = request.scope["query_string"].decode(self.DECODE_FORMAT).lower()
-        #request.scope["query_string"] = raw.encode(self.DECODE_FORMAT)
 
         response = await call_next(request)
         return response

--- a/titiler/application/titiler/application/middleware.py
+++ b/titiler/application/titiler/application/middleware.py
@@ -98,8 +98,15 @@ class LowerCaseQueryStringMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         self.DECODE_FORMAT = "latin-1"
 
-        raw = request.scope["query_string"].decode(self.DECODE_FORMAT).lower()
-        request.scope["query_string"] = raw.encode(self.DECODE_FORMAT)
+        query_string = ""
+        for k in request.query_params:
+            query_string += k.lower() + '=' + request.query_params[k]
+        request.scope["query_string"] = query_string.encode(self.DECODE_FORMAT)
+
+        print(request.scope["query_string"])
+
+        #raw = request.scope["query_string"].decode(self.DECODE_FORMAT).lower()
+        #request.scope["query_string"] = raw.encode(self.DECODE_FORMAT)
 
         response = await call_next(request)
         return response

--- a/titiler/application/titiler/application/middleware.py
+++ b/titiler/application/titiler/application/middleware.py
@@ -90,7 +90,7 @@ class LoggerMiddleware(BaseHTTPMiddleware):
         return response
 
 
-class CaseInsensitiveMiddleware(BaseHTTPMiddleware):
+class LowerCaseQueryStringMiddleware(BaseHTTPMiddleware):
     """Middleware to make URL parameters case-insensitive.
     taken from: https://github.com/tiangolo/fastapi/issues/826
     """

--- a/titiler/application/titiler/application/settings.py
+++ b/titiler/application/titiler/application/settings.py
@@ -15,6 +15,8 @@ class ApiSettings(pydantic.BaseSettings):
     disable_stac: bool = False
     disable_mosaic: bool = False
 
+    lower_case_query_parameters: bool = False
+
     @pydantic.validator("cors_origins")
     def parse_cors_origin(cls, v):
         """Parse CORS origins."""


### PR DESCRIPTION
changed middleware to LowerCaseQueryStringMiddleware and made it optional with API setting. Hack to lowercase only query keys.